### PR TITLE
ビットレートの調整

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -28,6 +28,7 @@ import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.twilio.video.BaseTrackStats;
 import com.twilio.video.CameraCapturer;
 import com.twilio.video.ConnectOptions;
+import com.twilio.video.EncodingParameters;
 import com.twilio.video.LocalParticipant;
 import com.twilio.video.LocalAudioTrack;
 import com.twilio.video.LocalAudioTrackStats;
@@ -313,6 +314,8 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
          */
         setAudioFocus(true);
         ConnectOptions.Builder connectOptionsBuilder = new ConnectOptions.Builder(this.accessToken);
+
+        connectOptionsBuilder.encodingParameters(new EncodingParameters(20000, 40000));
 
         if (this.roomName != null) {
             connectOptionsBuilder.roomName(this.roomName);

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -266,6 +266,7 @@ RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName)
       builder.audioTracks = @[self.localAudioTrack];
     }
 
+    builder.encodingParameters = [[TVIEncodingParameters alloc] initWithAudioBitrate:20000 videoBitrate:40000];
     builder.roomName = roomName;
   }];
 


### PR DESCRIPTION
デフォルトだとビットレートが高すぎるため、
不要に画質・音質が高くなり通信に付加をかけてしまうので調整する。

<img width="425" alt="2018-08-10 10 12 07" src="https://user-images.githubusercontent.com/6793256/43934656-562c3e0a-9c8b-11e8-82f7-977d12d582d0.png">

とりあえずWebの生徒側に合わせて
```
Audio: 20000
Video: 40000
```
で設定してある